### PR TITLE
feat: Implement initial Go component service with CRUD API and Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Stage 1: Build the Go application
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Copy go.mod and go.sum files
+COPY go.mod go.sum ./
+
+# Download Go modules
+RUN go mod download
+
+# Copy the source code
+COPY . .
+
+# Build the application
+# Using CGO_ENABLED=0 to build a statically linked binary (recommended for alpine)
+# Using -ldflags="-w -s" to strip debug information and reduce binary size (optional)
+RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /app/explorer-server main.go
+
+# Stage 2: Create the final lightweight image
+FROM alpine:latest
+
+WORKDIR /app
+
+# Copy the built binary from the builder stage
+COPY --from=builder /app/explorer-server /app/explorer-server
+
+# Copy the schema.sql file (for reference or potential use)
+COPY schema.sql /app/schema.sql
+
+# Expose the port the application runs on
+EXPOSE 8080
+
+# Set the default command to run the application
+# The application will respect the PORT environment variable if set, otherwise defaults to 8080 (as coded in main.go)
+CMD ["/app/explorer-server"]

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -1,0 +1,171 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+
+	"explorer-server/models" // Assuming explorer-server is the module name
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+)
+
+// DB holds the database connection.
+type DB struct {
+	*sql.DB
+}
+
+// NewDB establishes a new database connection and returns a DB instance.
+func NewDB(dataSourceName string) (*DB, error) {
+	conn, err := sql.Open("postgres", dataSourceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database connection: %w", err)
+	}
+
+	if err = conn.Ping(); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	return &DB{conn}, nil
+}
+
+// CreateComponent inserts a new component into the components table.
+// It assumes component.ID is already populated with a UUID string.
+func (db *DB) CreateComponent(component *models.Component) error {
+	query := `
+		INSERT INTO components (id, name, parent_id)
+		VALUES ($1, $2, $3)
+	`
+	var parentID sql.NullString
+	if component.ParentID != nil {
+		parentID = sql.NullString{String: *component.ParentID, Valid: true}
+	} else {
+		parentID = sql.NullString{Valid: false}
+	}
+
+	_, err := db.Exec(query, component.ID, component.Name, parentID)
+	if err != nil {
+		return fmt.Errorf("failed to insert component: %w", err)
+	}
+	return nil
+}
+
+// GetComponentByID retrieves a component by its ID.
+// It returns sql.ErrNoRows if no component is found.
+func (db *DB) GetComponentByID(id string) (*models.Component, error) {
+	query := `
+		SELECT id, name, parent_id
+		FROM components
+		WHERE id = $1
+	`
+	row := db.QueryRow(query, id)
+
+	component := &models.Component{}
+	var parentID sql.NullString
+
+	err := row.Scan(&component.ID, &component.Name, &parentID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, sql.ErrNoRows
+		}
+		return nil, fmt.Errorf("failed to scan component: %w", err)
+	}
+
+	if parentID.Valid {
+		component.ParentID = &parentID.String
+	}
+
+	return component, nil
+}
+
+// GetAllComponents retrieves all components from the database, ordered by name.
+func (db *DB) GetAllComponents() ([]*models.Component, error) {
+	query := `
+		SELECT id, name, parent_id
+		FROM components
+		ORDER BY name
+	`
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query components: %w", err)
+	}
+	defer rows.Close()
+
+	var components []*models.Component
+	for rows.Next() {
+		component := &models.Component{}
+		var parentID sql.NullString
+
+		err := rows.Scan(&component.ID, &component.Name, &parentID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan component row: %w", err)
+		}
+
+		if parentID.Valid {
+			component.ParentID = &parentID.String
+		}
+		components = append(components, component)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error during rows iteration: %w", err)
+	}
+
+	return components, nil
+}
+
+// UpdateComponent updates an existing component in the database.
+// It returns sql.ErrNoRows if no component with the given ID is found.
+func (db *DB) UpdateComponent(id string, component *models.Component) error {
+	query := `
+		UPDATE components
+		SET name = $1, parent_id = $2
+		WHERE id = $3
+	`
+	var parentID sql.NullString
+	if component.ParentID != nil {
+		parentID = sql.NullString{String: *component.ParentID, Valid: true}
+	} else {
+		parentID = sql.NullString{Valid: false}
+	}
+
+	result, err := db.Exec(query, component.Name, parentID, id)
+	if err != nil {
+		return fmt.Errorf("failed to update component: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return sql.ErrNoRows // Or a custom error like fmt.Errorf("component with ID %s not found", id)
+	}
+
+	return nil
+}
+
+// DeleteComponent removes a component from the database by its ID.
+// It returns sql.ErrNoRows if no component with the given ID is found.
+func (db *DB) DeleteComponent(id string) error {
+	query := `
+		DELETE FROM components
+		WHERE id = $1
+	`
+	result, err := db.Exec(query, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete component: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return sql.ErrNoRows // Or a custom error like fmt.Errorf("component with ID %s not found", id)
+	}
+
+	return nil
+}

--- a/db/postgres_test.go
+++ b/db/postgres_test.go
@@ -1,0 +1,421 @@
+package db
+
+import (
+	"database/sql"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"explorer-server/models"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+)
+
+var testDB *DB
+
+// TestMain sets up the database connection and schema for all tests in this package.
+// It's run once before any tests and cleans up after all tests are done.
+func TestMain(m *testing.M) {
+	testDatabaseURL := os.Getenv("TEST_DATABASE_URL")
+	if testDatabaseURL == "" {
+		log.Println("TEST_DATABASE_URL not set, skipping database tests.")
+		// Exit with success if no DB URL, as we can't run tests.
+		// Alternatively, os.Exit(0) if tests shouldn't be "skipped" but just not run.
+		// For CI, it's better to explicitly skip or fail.
+		// For now, we'll let individual tests handle the nil testDB.
+	}
+
+	var err error
+	if testDatabaseURL != "" { // Only attempt connection if URL is provided
+		conn, err := sql.Open("postgres", testDatabaseURL)
+		if err != nil {
+			log.Fatalf("Failed to open test database connection: %v", err)
+		}
+		if err = conn.Ping(); err != nil {
+			conn.Close()
+			log.Fatalf("Failed to ping test database: %v", err)
+		}
+		testDB = &DB{conn}
+
+		// Apply schema
+		// Assuming schema.sql is in the parent directory relative to this test file's directory.
+		schemaPath := filepath.Join("..", "schema.sql")
+		schemaBytes, err := ioutil.ReadFile(schemaPath)
+		if err != nil {
+			testDB.Close()
+			log.Fatalf("Failed to read schema.sql at %s: %v", schemaPath, err)
+		}
+		if _, err := testDB.Exec(string(schemaBytes)); err != nil {
+			testDB.Close()
+			log.Fatalf("Failed to apply schema: %v", err)
+		}
+		log.Println("Test database schema applied successfully.")
+	}
+
+	// Run tests
+	exitCode := m.Run()
+
+	// Clean up: Close database connection if it was opened
+	if testDB != nil {
+		// Optionally, drop tables here if desired, or clear them.
+		// For simplicity, just closing the connection.
+		testDB.Close()
+		log.Println("Test database connection closed.")
+	}
+	os.Exit(exitCode)
+}
+
+// clearComponentsTable is a helper to delete all rows from components.
+func clearComponentsTable(t *testing.T) {
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, skipping test.")
+		return
+	}
+	_, err := testDB.Exec("DELETE FROM components")
+	if err != nil {
+		t.Fatalf("Failed to clear components table: %v", err)
+	}
+	// Reset sequences if any (not strictly necessary for UUIDs as strings)
+	// _, err = testDB.Exec("ALTER SEQUENCE components_id_seq RESTART WITH 1") // If using serial IDs
+}
+
+// Helper to create a component for testing, fails test on error
+func createTestComponent(t *testing.T, db *DB, comp *models.Component) {
+	t.Helper()
+	err := db.CreateComponent(comp)
+	if err != nil {
+		t.Fatalf("Failed to create test component (ID: %s): %v", comp.ID, err)
+	}
+}
+
+
+func TestCreateComponent(t *testing.T) {
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, skipping test.")
+		return
+	}
+	clearComponentsTable(t)
+
+	parentID := "parent-uuid-for-create"
+	parentComp := &models.Component{ID: parentID, Name: "Parent For Create"}
+	createTestComponent(t, testDB, parentComp)
+
+
+	comp1 := &models.Component{
+		ID:   "test-create-1",
+		Name: "Component Create 1",
+	}
+	comp2 := &models.Component{
+		ID:       "test-create-2",
+		Name:     "Component Create 2 With Parent",
+		ParentID: &parentID,
+	}
+
+	tests := []struct {
+		name      string
+		component *models.Component
+		wantErr   bool
+	}{
+		{"create component without parent", comp1, false},
+		{"create component with parent", comp2, false},
+		{"create component with duplicate ID", &models.Component{ID: "test-create-1", Name: "Duplicate"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testDB.CreateComponent(tt.component)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateComponent() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				retrieved, errGet := testDB.GetComponentByID(tt.component.ID)
+				if errGet != nil {
+					t.Fatalf("Failed to retrieve created component: %v", errGet)
+				}
+				if !reflect.DeepEqual(retrieved, tt.component) {
+					t.Errorf("Retrieved component = %v, want %v", retrieved, tt.component)
+				}
+			}
+		})
+	}
+}
+
+func TestGetComponentByID(t *testing.T) {
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, skipping test.")
+		return
+	}
+	clearComponentsTable(t)
+
+	parentID := "parent-uuid-for-get"
+	parentComp := &models.Component{ID: parentID, Name: "Parent For Get"}
+	createTestComponent(t, testDB, parentComp)
+
+	comp := &models.Component{
+		ID:       "test-get-1",
+		Name:     "Component Get 1",
+		ParentID: &parentID,
+	}
+	createTestComponent(t, testDB, comp)
+
+	tests := []struct {
+		name      string
+		id        string
+		want      *models.Component
+		wantErr   error
+	}{
+		{"get existing component", comp.ID, comp, nil},
+		{"get non-existent component", "non-existent-id", nil, sql.ErrNoRows},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := testDB.GetComponentByID(tt.id)
+			if err != tt.wantErr {
+				t.Errorf("GetComponentByID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetComponentByID() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAllComponents(t *testing.T) {
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, skipping test.")
+		return
+	}
+	clearComponentsTable(t)
+
+	parentID := "parent-uuid-for-getall"
+	parentComp := &models.Component{ID: parentID, Name: "Parent For GetAll"} // Z name to test sorting later
+	createTestComponent(t, testDB, parentComp)
+
+	comp1 := &models.Component{ID: "test-getall-1", Name: "B Component"} // B for sorting
+	comp2 := &models.Component{ID: "test-getall-2", Name: "A Component With Parent", ParentID: &parentID} // A for sorting
+
+	createTestComponent(t, testDB, comp1) // Create comp1 (B)
+	createTestComponent(t, testDB, comp2) // Create comp2 (A)
+
+	// Expected order: comp2 (A), comp1 (B), parentComp (Parent/Z) - based on current db.GetAllComponents ordering by name
+	// Corrected expected order: A, B, Parent (as per current implementation)
+	expectedComponents := []*models.Component{comp2, comp1, parentComp}
+	// Sort expectedComponents by name to match the function's behavior
+	sort.Slice(expectedComponents, func(i, j int) bool {
+		return expectedComponents[i].Name < expectedComponents[j].Name
+	})
+
+
+	t.Run("get all components when table has entries", func(t *testing.T) {
+		got, err := testDB.GetAllComponents()
+		if err != nil {
+			t.Fatalf("GetAllComponents() error = %v", err)
+		}
+		if !reflect.DeepEqual(got, expectedComponents) {
+			t.Errorf("GetAllComponents() got = %#v, want %#v", got, expectedComponents)
+			for i := range got {
+				if i < len(expectedComponents) && !reflect.DeepEqual(got[i], expectedComponents[i]) {
+					t.Errorf("Mismatch at index %d: got %v, want %v", i, got[i], expectedComponents[i])
+				}
+			}
+		}
+	})
+
+	t.Run("get all components when table is empty", func(t *testing.T) {
+		clearComponentsTable(t)
+		got, err := testDB.GetAllComponents()
+		if err != nil {
+			t.Fatalf("GetAllComponents() error on empty table = %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("GetAllComponents() on empty table got %v, want empty slice", got)
+		}
+	})
+}
+
+func TestUpdateComponent(t *testing.T) {
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, skipping test.")
+		return
+	}
+	clearComponentsTable(t)
+
+	parent1ID := "parent-update-1"
+	parent2ID := "parent-update-2"
+	createTestComponent(t, testDB, &models.Component{ID: parent1ID, Name: "Parent Update 1"})
+	createTestComponent(t, testDB, &models.Component{ID: parent2ID, Name: "Parent Update 2"})
+
+	compToUpdate := &models.Component{
+		ID:       "test-update-1",
+		Name:     "Original Name",
+		ParentID: &parent1ID,
+	}
+	createTestComponent(t, testDB, compToUpdate)
+
+	updates := &models.Component{ // Name and ParentID are part of models.Component
+		Name:     "Updated Name",
+		ParentID: &parent2ID, // Change parent
+	}
+
+	updatesNoParent := &models.Component{
+		Name:     "Updated Name No Parent",
+		ParentID: nil, // Set parent to NULL
+	}
+
+
+	t.Run("update existing component name and parent", func(t *testing.T) {
+		err := testDB.UpdateComponent(compToUpdate.ID, updates)
+		if err != nil {
+			t.Fatalf("UpdateComponent() error = %v", err)
+		}
+		retrieved, _ := testDB.GetComponentByID(compToUpdate.ID)
+		// The ID of 'updates' is not set, and UpdateComponent doesn't update ID.
+		// So, the retrieved component's ID will be compToUpdate.ID.
+		// We need to compare Name and ParentID.
+		if retrieved.Name != updates.Name || (retrieved.ParentID == nil && updates.ParentID != nil) || (retrieved.ParentID != nil && updates.ParentID == nil) || (retrieved.ParentID != nil && updates.ParentID != nil && *retrieved.ParentID != *updates.ParentID) {
+			t.Errorf("UpdateComponent() got Name %s, ParentID %v; want Name %s, ParentID %v",
+				retrieved.Name, retrieved.ParentID, updates.Name, updates.ParentID)
+		}
+	})
+
+	// Restore for next test case
+	createTestComponent(t, testDB, &models.Component{ID: "test-update-restore", Name: "To Be Restored"}) // Create a dummy to clear table
+	clearComponentsTable(t)
+	createTestComponent(t, testDB, &models.Component{ID: parent1ID, Name: "Parent Update 1"})
+    createTestComponent(t, testDB, compToUpdate) // recreate compToUpdate with original parent1ID
+
+	t.Run("update existing component to have no parent", func(t *testing.T) {
+		err := testDB.UpdateComponent(compToUpdate.ID, updatesNoParent)
+		if err != nil {
+			t.Fatalf("UpdateComponent() error = %v", err)
+		}
+		retrieved, _ := testDB.GetComponentByID(compToUpdate.ID)
+		if retrieved.Name != updatesNoParent.Name || retrieved.ParentID != nil {
+			t.Errorf("UpdateComponent() got Name %s, ParentID %v; want Name %s, ParentID nil",
+				retrieved.Name, retrieved.ParentID, updatesNoParent.Name)
+		}
+	})
+
+
+	t.Run("update non-existent component", func(t *testing.T) {
+		err := testDB.UpdateComponent("non-existent-id", updates)
+		if err != sql.ErrNoRows {
+			t.Errorf("UpdateComponent() on non-existent ID error = %v, want %v", err, sql.ErrNoRows)
+		}
+	})
+}
+
+func TestDeleteComponent(t *testing.T) {
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, skipping test.")
+		return
+	}
+	clearComponentsTable(t)
+
+	compToDelete := &models.Component{ID: "test-delete-1", Name: "To Be Deleted"}
+	createTestComponent(t, testDB, compToDelete)
+
+	t.Run("delete existing component", func(t *testing.T) {
+		err := testDB.DeleteComponent(compToDelete.ID)
+		if err != nil {
+			t.Fatalf("DeleteComponent() error = %v", err)
+		}
+		_, errGet := testDB.GetComponentByID(compToDelete.ID)
+		if errGet != sql.ErrNoRows {
+			t.Errorf("GetComponentByID() after delete error = %v, want %v", errGet, sql.ErrNoRows)
+		}
+	})
+
+	t.Run("delete non-existent component", func(t *testing.T) {
+		err := testDB.DeleteComponent("non-existent-id")
+		if err != sql.ErrNoRows {
+			t.Errorf("DeleteComponent() on non-existent ID error = %v, want %v", err, sql.ErrNoRows)
+		}
+	})
+
+	// Test cascading delete (ON DELETE SET NULL for parent_id)
+	parentCompID := "parent-casc-delete"
+	childCompID := "child-casc-delete"
+	createTestComponent(t, testDB, &models.Component{ID: parentCompID, Name: "Parent For Cascade Delete Test"})
+	createTestComponent(t, testDB, &models.Component{ID: childCompID, Name: "Child For Cascade Delete Test", ParentID: &parentCompID})
+
+	t.Run("delete parent component and check child's parent_id is NULL", func(t *testing.T) {
+		// Delete the parent
+		err := testDB.DeleteComponent(parentCompID)
+		if err != nil {
+			t.Fatalf("Failed to delete parent component for cascade test: %v", err)
+		}
+
+		// Check the child component
+		childComp, err := testDB.GetComponentByID(childCompID)
+		if err != nil {
+			t.Fatalf("Failed to get child component after parent deletion: %v", err)
+		}
+		if childComp.ParentID != nil {
+			t.Errorf("Child component's ParentID is %v, expected nil after parent deletion due to ON DELETE SET NULL", *childComp.ParentID)
+		}
+	})
+}
+
+// Test for ON DELETE SET NULL with multiple children
+func TestDeleteComponent_CascadeSetNullMultipleChildren(t *testing.T) {
+    if testDB == nil {
+        t.Skip("TEST_DATABASE_URL not set, skipping test.")
+        return
+    }
+    clearComponentsTable(t)
+
+    parentID := "parent-multi-child-delete"
+    child1ID := "child1-multi-delete"
+    child2ID := "child2-multi-delete"
+    grandChildID := "grandchild-multi-delete" // Child of child1
+
+    // Create parent and children
+    createTestComponent(t, testDB, &models.Component{ID: parentID, Name: "Parent Multi Child"})
+    createTestComponent(t, testDB, &models.Component{ID: child1ID, Name: "Child1 Multi", ParentID: &parentID})
+    createTestComponent(t, testDB, &models.Component{ID: child2ID, Name: "Child2 Multi", ParentID: &parentID})
+    createTestComponent(t, testDB, &models.Component{ID: grandChildID, Name: "GrandChild of Child1", ParentID: &child1ID})
+
+
+    // Delete the parent
+    err := testDB.DeleteComponent(parentID)
+    if err != nil {
+        t.Fatalf("Failed to delete parent component: %v", err)
+    }
+
+    // Check child1
+    child1, err := testDB.GetComponentByID(child1ID)
+    if err != nil {
+        t.Fatalf("Failed to get child1 component: %v", err)
+    }
+    if child1.ParentID != nil {
+        t.Errorf("Child1's ParentID expected to be NULL, got %s", *child1.ParentID)
+    }
+
+    // Check child2
+    child2, err := testDB.GetComponentByID(child2ID)
+    if err != nil {
+        t.Fatalf("Failed to get child2 component: %v", err)
+    }
+    if child2.ParentID != nil {
+        t.Errorf("Child2's ParentID expected to be NULL, got %s", *child2.ParentID)
+    }
+
+    // Grandchild should still have child1ID as parent, but child1 has no parent.
+    // This is correct behavior. The grandchild's parent_id still points to child1's ID.
+    // If child1 were also deleted, then grandchild's parent_id would also become NULL if it referenced child1.
+    grandChild, err := testDB.GetComponentByID(grandChildID)
+    if err != nil {
+        t.Fatalf("Failed to get grandchild component: %v", err)
+    }
+    if grandChild.ParentID == nil || *grandChild.ParentID != child1ID {
+        t.Errorf("Grandchild's ParentID expected to be %s, got %v", child1ID, grandChild.ParentID)
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module explorer-server
+
+go 1.22.2
+
+require github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/handlers/component_handlers.go
+++ b/handlers/component_handlers.go
@@ -1,0 +1,168 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"explorer-server/db"
+	"explorer-server/models"
+)
+
+// ComponentHandler holds the database context for component operations.
+type ComponentHandler struct {
+	DB *db.DB
+}
+
+// NewComponentHandler creates a new ComponentHandler.
+func NewComponentHandler(database *db.DB) *ComponentHandler {
+	return &ComponentHandler{DB: database}
+}
+
+// CreateComponentHandler handles POST requests to /components.
+// It expects a models.Component in the request body, including its ID.
+func (h *ComponentHandler) CreateComponentHandler(w http.ResponseWriter, r *http.Request) {
+	var component models.Component
+	if err := json.NewDecoder(r.Body).Decode(&component); err != nil {
+		http.Error(w, "Invalid request payload: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	// Basic validation: Check if ID and Name are provided
+	if component.ID == "" || component.Name == "" {
+		http.Error(w, "Component ID and Name are required", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.DB.CreateComponent(&component); err != nil {
+		// This could be a duplicate ID error or other database constraint violation
+		// For simplicity, returning 500, but could be more specific (e.g., 409 Conflict)
+		http.Error(w, "Failed to create component: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(component); err != nil {
+		// If encoding fails, it's an internal server error, though the component was created.
+		// Log this error on the server side.
+		// Consider logging the error properly in a real application.
+		http.Error(w, "Failed to write response: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// UpdateComponentHandler handles PUT requests to /components/{id}.
+func (h *ComponentHandler) UpdateComponentHandler(w http.ResponseWriter, r *http.Request) {
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 3 || pathParts[2] == "" { // Expecting /components/{id}
+		http.Error(w, "Component ID is missing in URL path", http.StatusBadRequest)
+		return
+	}
+	id := pathParts[len(pathParts)-1] // Get the last part as ID
+
+	var componentUpdates models.Component
+	if err := json.NewDecoder(r.Body).Decode(&componentUpdates); err != nil {
+		http.Error(w, "Invalid request payload: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	// Basic validation: Name is required for an update
+	if componentUpdates.Name == "" {
+		http.Error(w, "Component Name is required for update", http.StatusBadRequest)
+		return
+	}
+
+	// The ID for update comes from the URL, not the body.
+	// componentUpdates.ID will be ignored by the db.UpdateComponent if it expects the id as a separate param.
+	// If db.UpdateComponent used componentUpdates.ID, we'd need to set it here: componentUpdates.ID = id
+
+	err := h.DB.UpdateComponent(id, &componentUpdates)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			http.Error(w, "Component not found to update", http.StatusNotFound)
+		} else {
+			http.Error(w, "Failed to update component: "+err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// Fetch the updated component to return it, as UpdateComponent itself doesn't return the model
+	// This is optional; some APIs might just return 200 OK or 204 No Content.
+	// For consistency with Create, returning the updated model.
+	updatedComponent, err := h.DB.GetComponentByID(id)
+	if err != nil {
+		// This would be unusual if the update succeeded.
+		http.Error(w, "Failed to retrieve updated component: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(updatedComponent); err != nil {
+		http.Error(w, "Failed to write response: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// DeleteComponentHandler handles DELETE requests to /components/{id}.
+func (h *ComponentHandler) DeleteComponentHandler(w http.ResponseWriter, r *http.Request) {
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 3 || pathParts[2] == "" { // Expecting /components/{id}
+		http.Error(w, "Component ID is missing in URL path", http.StatusBadRequest)
+		return
+	}
+	id := pathParts[len(pathParts)-1] // Get the last part as ID
+
+	err := h.DB.DeleteComponent(id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			http.Error(w, "Component not found to delete", http.StatusNotFound)
+		} else {
+			http.Error(w, "Failed to delete component: "+err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetComponentByIDHandler handles GET requests to /components/{id}.
+func (h *ComponentHandler) GetComponentByIDHandler(w http.ResponseWriter, r *http.Request) {
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 3 || pathParts[2] == "" { // Expecting /components/{id}
+		http.Error(w, "Component ID is missing in URL path", http.StatusBadRequest)
+		return
+	}
+	id := pathParts[len(pathParts)-1] // Get the last part as ID
+
+	component, err := h.DB.GetComponentByID(id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			http.Error(w, "Component not found", http.StatusNotFound)
+		} else {
+			http.Error(w, "Failed to retrieve component: "+err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(component); err != nil {
+		http.Error(w, "Failed to write response: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// GetAllComponentsHandler handles GET requests to /components.
+func (h *ComponentHandler) GetAllComponentsHandler(w http.ResponseWriter, r *http.Request) {
+	components, err := h.DB.GetAllComponents()
+	if err != nil {
+		http.Error(w, "Failed to retrieve components: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(components); err != nil {
+		http.Error(w, "Failed to write response: "+err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/handlers/component_handlers_test.go
+++ b/handlers/component_handlers_test.go
@@ -1,0 +1,514 @@
+package handlers
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"explorer-server/db"
+	"explorer-server/models"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+)
+
+var testDB *db.DB
+var compHandler *ComponentHandler
+
+// TestMain sets up the database connection and schema for all tests in this package.
+func TestMain(m *testing.M) {
+	testDatabaseURL := os.Getenv("TEST_DATABASE_URL")
+	if testDatabaseURL == "" {
+		log.Println("TEST_DATABASE_URL not set, skipping handler tests.")
+	}
+
+	var err error
+	if testDatabaseURL != "" {
+		conn, errSqlOpen := sql.Open("postgres", testDatabaseURL)
+		if errSqlOpen != nil {
+			log.Fatalf("Failed to open test database connection: %v", errSqlOpen)
+		}
+		if errPing := conn.Ping(); errPing != nil {
+			conn.Close()
+			log.Fatalf("Failed to ping test database: %v", errPing)
+		}
+		testDB = &db.DB{DB: conn} // Correctly initialize the custom DB struct
+
+		schemaPath := filepath.Join("..", "schema.sql")
+		schemaBytes, errRead := ioutil.ReadFile(schemaPath)
+		if errRead != nil {
+			testDB.Close()
+			log.Fatalf("Failed to read schema.sql at %s: %v", schemaPath, errRead)
+		}
+		if _, errExec := testDB.Exec(string(schemaBytes)); errExec != nil {
+			testDB.Close()
+			log.Fatalf("Failed to apply schema: %v", errExec)
+		}
+		log.Println("Test database schema applied successfully for handlers.")
+		compHandler = NewComponentHandler(testDB)
+	}
+
+	exitCode := m.Run()
+
+	if testDB != nil {
+		testDB.Close()
+		log.Println("Test database connection closed for handlers.")
+	}
+	os.Exit(exitCode)
+}
+
+// clearComponentsTableHandlerTests is a helper to delete all rows from components.
+func clearComponentsTableHandlerTests(t *testing.T) {
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, skipping test that requires DB.")
+		return
+	}
+	_, err := testDB.Exec("DELETE FROM components")
+	if err != nil {
+		t.Fatalf("Failed to clear components table: %v", err)
+	}
+}
+
+// Helper to create a component directly in DB for test setup
+func createDBTestComponent(t *testing.T, comp *models.Component) {
+	t.Helper()
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, cannot create test component.")
+		return
+	}
+	err := testDB.CreateComponent(comp)
+	if err != nil {
+		t.Fatalf("Failed to create test component in DB (ID: %s): %v", comp.ID, err)
+	}
+}
+
+
+func TestCreateComponentHandler(t *testing.T) {
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, skipping test.")
+		return
+	}
+	clearComponentsTableHandlerTests(t)
+
+	parentID := "parent-handler-create"
+	createDBTestComponent(t, &models.Component{ID: parentID, Name: "Parent For Handler Create"})
+
+
+	tests := []struct {
+		name         string
+		payload      interface{}
+		expectedCode int
+		expectedBody *models.Component // Only if successful
+	}{
+		{
+			name: "valid component no parent",
+			payload: models.Component{ID: "handler-create-1", Name: "Handler Create 1"},
+			expectedCode: http.StatusCreated,
+			expectedBody: &models.Component{ID: "handler-create-1", Name: "Handler Create 1"},
+		},
+		{
+			name: "valid component with parent",
+			payload: models.Component{ID: "handler-create-2", Name: "Handler Create 2", ParentID: &parentID},
+			expectedCode: http.StatusCreated,
+			expectedBody: &models.Component{ID: "handler-create-2", Name: "Handler Create 2", ParentID: &parentID},
+		},
+		{
+			name: "invalid JSON payload",
+			payload: "not a json",
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "missing component ID",
+			payload: models.Component{Name: "Missing ID"},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "missing component Name",
+			payload: models.Component{ID: "handler-create-no-name"},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "duplicate component ID",
+			payload: models.Component{ID: "handler-create-1", Name: "Duplicate"}, // handler-create-1 created in first test case
+			expectedCode: http.StatusInternalServerError, // Or 409 if db layer returns a specific error
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Ensure first component is created for duplicate test, then clear for next test runs if needed
+			if tt.name == "duplicate component ID" {
+				// No specific setup here, relies on previous successful creation.
+				// If tests run in parallel or order changes, this might need explicit setup.
+			} else if tt.name != "valid component no parent" { // Avoid double clear if first test
+				// For most tests, ensure a clean slate for this specific sub-test,
+				// especially if previous sub-tests might have left conflicting data.
+				// However, the current duplicate test relies on the state from "valid component no parent".
+				// This highlights complexity in ordered sub-tests vs. fully isolated ones.
+				// For now, let's proceed, but ideally, each sub-test should set up its own specific preconditions.
+			}
+
+
+			var bodyBytes []byte
+			var err error
+			if tt.payload != nil {
+				bodyBytes, err = json.Marshal(tt.payload)
+				if err != nil {
+					t.Fatalf("Failed to marshal payload: %v", err)
+				}
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "/components", bytes.NewBuffer(bodyBytes))
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+			rr := httptest.NewRecorder()
+			compHandler.CreateComponentHandler(rr, req)
+
+			if rr.Code != tt.expectedCode {
+				t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", rr.Code, tt.expectedCode, rr.Body.String())
+			}
+
+			if tt.expectedCode == http.StatusCreated {
+				if contentType := rr.Header().Get("Content-Type"); contentType != "application/json" {
+					t.Errorf("handler returned wrong content type: got %s want application/json", contentType)
+				}
+				var actualBody models.Component
+				if err := json.NewDecoder(rr.Body).Decode(&actualBody); err != nil {
+					t.Fatalf("Failed to decode response body: %v", err)
+				}
+				if !reflect.DeepEqual(&actualBody, tt.expectedBody) {
+					t.Errorf("handler returned unexpected body: got %v want %v", &actualBody, tt.expectedBody)
+				}
+			}
+		})
+	}
+}
+
+func TestGetComponentByIDHandler(t *testing.T) {
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, skipping test.")
+		return
+	}
+	clearComponentsTableHandlerTests(t)
+
+	comp := &models.Component{ID: "handler-get-1", Name: "Handler Get 1"}
+	createDBTestComponent(t, comp)
+
+	tests := []struct {
+		name         string
+		id           string
+		expectedCode int
+		expectedBody *models.Component
+	}{
+		{"get existing component", comp.ID, http.StatusOK, comp},
+		{"get non-existent component", "non-existent-id", http.StatusNotFound, nil},
+		{"get component with empty id in path", "", http.StatusBadRequest, nil}, // Test router/handler path parsing robustness
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "/components/"+tt.id, nil)
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+			rr := httptest.NewRecorder()
+			compHandler.GetComponentByIDHandler(rr, req)
+
+			if rr.Code != tt.expectedCode {
+				t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", rr.Code, tt.expectedCode, rr.Body.String())
+			}
+
+			if tt.expectedCode == http.StatusOK {
+				if contentType := rr.Header().Get("Content-Type"); contentType != "application/json" {
+					t.Errorf("handler returned wrong content type: got %s want application/json", contentType)
+				}
+				var actualBody models.Component
+				if err := json.NewDecoder(rr.Body).Decode(&actualBody); err != nil {
+					t.Fatalf("Failed to decode response body: %v", err)
+				}
+				if !reflect.DeepEqual(&actualBody, tt.expectedBody) {
+					t.Errorf("handler returned unexpected body: got %v want %v", &actualBody, tt.expectedBody)
+				}
+			}
+		})
+	}
+}
+
+func TestGetAllComponentsHandler(t *testing.T) {
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, skipping test.")
+		return
+	}
+
+	comp1 := &models.Component{ID: "handler-getall-1", Name: "B Handler GetAll"}
+	comp2 := &models.Component{ID: "handler-getall-2", Name: "A Handler GetAll"}
+
+	// Expected order due to DB sort by name
+	expectedSorted := []*models.Component{comp2, comp1}
+	sort.Slice(expectedSorted, func(i, j int) bool { // Ensure test expectation matches db sort
+        return expectedSorted[i].Name < expectedSorted[j].Name
+    })
+
+
+	tests := []struct {
+		name         string
+		setup        func()
+		expectedCode int
+		expectedBody []*models.Component
+	}{
+		{
+			name: "get all when components exist",
+			setup: func() {
+				clearComponentsTableHandlerTests(t)
+				createDBTestComponent(t, comp1)
+				createDBTestComponent(t, comp2)
+			},
+			expectedCode: http.StatusOK,
+			expectedBody: expectedSorted,
+		},
+		{
+			name: "get all when no components exist",
+			setup: func() {
+				clearComponentsTableHandlerTests(t)
+			},
+			expectedCode: http.StatusOK,
+			expectedBody: []*models.Component{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			req, err := http.NewRequest(http.MethodGet, "/components", nil)
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+			rr := httptest.NewRecorder()
+			compHandler.GetAllComponentsHandler(rr, req)
+
+			if rr.Code != tt.expectedCode {
+				t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", rr.Code, tt.expectedCode, rr.Body.String())
+			}
+
+			if contentType := rr.Header().Get("Content-Type"); contentType != "application/json" {
+				t.Errorf("handler returned wrong content type: got %s want application/json", contentType)
+			}
+
+			var actualBody []*models.Component
+			// For empty array, Decode might err if body is empty vs "[]"
+			// httptest.Recorder.Body is a *bytes.Buffer, which is empty if nothing written.
+			// json.NewDecoder will error on empty input if it expects an array/object.
+			if rr.Body.Len() > 0 { // Check if there's anything to decode
+				if err := json.NewDecoder(rr.Body).Decode(&actualBody); err != nil {
+					// If expecting empty array, and body is literally empty (not "[]"), this will fail.
+					// The handler should ensure it writes "[]" for empty lists.
+					if !(len(tt.expectedBody) == 0 && strings.TrimSpace(rr.Body.String()) == "") {
+						t.Fatalf("Failed to decode response body: %v. Body content: '%s'", err, rr.Body.String())
+					}
+				}
+			}
+			// If actualBody remained nil (due to empty body and empty expected) and expectedBody is empty slice, it's a pass.
+			if actualBody == nil && len(tt.expectedBody) == 0 {
+				// This is fine, signifies an empty list was correctly returned as empty or nil slice
+			} else if !reflect.DeepEqual(actualBody, tt.expectedBody) {
+				t.Errorf("handler returned unexpected body: got %#v want %#v", actualBody, tt.expectedBody)
+			}
+		})
+	}
+}
+
+
+func TestUpdateComponentHandler(t *testing.T) {
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, skipping test.")
+		return
+	}
+
+	originalCompID := "handler-update-1"
+	originalParentID := "parent-handler-update-orig"
+	newParentID := "parent-handler-update-new"
+
+
+	tests := []struct {
+		name         string
+		idToUpdate   string
+		payload      interface{}
+		setup        func()
+		expectedCode int
+		expectedBody *models.Component // Only if successful (200)
+	}{
+		{
+			name:       "valid update name and parent",
+			idToUpdate: originalCompID,
+			payload:    models.Component{Name: "Updated Name", ParentID: &newParentID},
+			setup: func() {
+				clearComponentsTableHandlerTests(t)
+				createDBTestComponent(t, &models.Component{ID: originalParentID, Name: "Original Parent"})
+				createDBTestComponent(t, &models.Component{ID: newParentID, Name: "New Parent"})
+				createDBTestComponent(t, &models.Component{ID: originalCompID, Name: "Original Name", ParentID: &originalParentID})
+			},
+			expectedCode: http.StatusOK,
+			expectedBody: &models.Component{ID: originalCompID, Name: "Updated Name", ParentID: &newParentID},
+		},
+		{
+			name:       "update to remove parent",
+			idToUpdate: originalCompID,
+			payload:    models.Component{Name: "Updated Name No Parent", ParentID: nil},
+			setup: func() {
+				clearComponentsTableHandlerTests(t)
+				createDBTestComponent(t, &models.Component{ID: originalParentID, Name: "Original Parent"})
+				createDBTestComponent(t, &models.Component{ID: originalCompID, Name: "Original Name", ParentID: &originalParentID})
+			},
+			expectedCode: http.StatusOK,
+			expectedBody: &models.Component{ID: originalCompID, Name: "Updated Name No Parent", ParentID: nil},
+		},
+		{
+			name:       "update non-existent component",
+			idToUpdate: "non-existent-id",
+			payload:    models.Component{Name: "Update Non Existent"},
+			setup:      clearComponentsTableHandlerTests,
+			expectedCode: http.StatusNotFound,
+		},
+		{
+			name:       "invalid JSON payload for update",
+			idToUpdate: originalCompID,
+			payload:    "not a json",
+			setup: func() { // Ensure component exists for this path, though payload is bad
+				clearComponentsTableHandlerTests(t)
+				createDBTestComponent(t, &models.Component{ID: originalCompID, Name: "Exists for bad JSON test"})
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:       "missing name in update payload",
+			idToUpdate: originalCompID,
+			payload:    models.Component{ParentID: &newParentID}, // Name is empty
+			setup: func() {
+				clearComponentsTableHandlerTests(t)
+				createDBTestComponent(t, &models.Component{ID: newParentID, Name: "New Parent"})
+				createDBTestComponent(t, &models.Component{ID: originalCompID, Name: "Exists for missing name test"})
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			var bodyBytes []byte
+			var err error
+			if tt.payload != nil {
+				bodyBytes, err = json.Marshal(tt.payload)
+				if err != nil {
+					t.Fatalf("Failed to marshal payload: %v", err)
+				}
+			}
+
+			req, err := http.NewRequest(http.MethodPut, "/components/"+tt.idToUpdate, bytes.NewBuffer(bodyBytes))
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+			rr := httptest.NewRecorder()
+			compHandler.UpdateComponentHandler(rr, req)
+
+			if rr.Code != tt.expectedCode {
+				t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", rr.Code, tt.expectedCode, rr.Body.String())
+			}
+
+			if tt.expectedCode == http.StatusOK {
+				if contentType := rr.Header().Get("Content-Type"); contentType != "application/json" {
+					t.Errorf("handler returned wrong content type: got %s want application/json", contentType)
+				}
+				var actualBody models.Component
+				if err := json.NewDecoder(rr.Body).Decode(&actualBody); err != nil {
+					t.Fatalf("Failed to decode response body: %v", err)
+				}
+				// Compare with expectedBody, ensuring ID matches idToUpdate
+				if tt.expectedBody.ID == "" { // If not set in test struct, fill from path
+					tt.expectedBody.ID = tt.idToUpdate
+				}
+				if !reflect.DeepEqual(&actualBody, tt.expectedBody) {
+					t.Errorf("handler returned unexpected body: got %#v want %#v", &actualBody, tt.expectedBody)
+				}
+			}
+		})
+	}
+}
+
+func TestDeleteComponentHandler(t *testing.T) {
+	if testDB == nil {
+		t.Skip("TEST_DATABASE_URL not set, skipping test.")
+		return
+	}
+
+	compID := "handler-delete-1"
+
+	tests := []struct {
+		name         string
+		idToDelete   string
+		setup        func()
+		expectedCode int
+	}{
+		{
+			name:       "delete existing component",
+			idToDelete: compID,
+			setup: func() {
+				clearComponentsTableHandlerTests(t)
+				createDBTestComponent(t, &models.Component{ID: compID, Name: "To Be Deleted By Handler"})
+			},
+			expectedCode: http.StatusNoContent,
+		},
+		{
+			name:       "delete non-existent component",
+			idToDelete: "non-existent-id",
+			setup:      clearComponentsTableHandlerTests,
+			expectedCode: http.StatusNotFound,
+		},
+		{
+			name: "delete component with empty id in path",
+			idToDelete: "", // Test router/handler path parsing robustness
+			setup: clearComponentsTableHandlerTests,
+			expectedCode: http.StatusBadRequest, // Or 404 if router handles it as not found
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			req, err := http.NewRequest(http.MethodDelete, "/components/"+tt.idToDelete, nil)
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+			rr := httptest.NewRecorder()
+			compHandler.DeleteComponentHandler(rr, req)
+
+			if rr.Code != tt.expectedCode {
+				t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", rr.Code, tt.expectedCode, rr.Body.String())
+			}
+
+			if tt.expectedCode == http.StatusNoContent {
+				// Verify component is actually deleted from DB
+				_, errDb := testDB.GetComponentByID(tt.idToDelete)
+				if errDb != sql.ErrNoRows {
+					t.Errorf("component %s not actually deleted from DB, err: %v", tt.idToDelete, errDb)
+				}
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"explorer-server/db"
+	"explorer-server/handlers"
+)
+
+func main() {
+	// 2a. Retrieve PostgreSQL connection string
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = "user=postgres password=password dbname=explorerdb sslmode=disable host=localhost port=5432"
+		log.Println("DATABASE_URL not set, using default:", databaseURL)
+	}
+
+	// 2b. Initialize the database connection
+	database, err := db.NewDB(databaseURL)
+	if err != nil {
+		log.Fatalf("Failed to connect to database: %v", err)
+	}
+	defer database.Close()
+
+	log.Println("Successfully connected to the database.")
+
+	// 2c. Create an instance of ComponentHandler
+	compHandler := handlers.NewComponentHandler(database)
+
+	// 2d. Set up an http.ServeMux as the router
+	mux := http.NewServeMux()
+
+	// 2e. Register handlers
+	// Handler for /components (POST for create, GET for list all)
+	mux.HandleFunc("/components", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			compHandler.CreateComponentHandler(w, r)
+		case http.MethodGet:
+			compHandler.GetAllComponentsHandler(w, r)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	// Handler for /components/{id} (GET by ID, PUT, DELETE)
+	// The trailing slash is important for ServeMux to catch all paths starting with /components/
+	mux.HandleFunc("/components/", func(w http.ResponseWriter, r *http.Request) {
+		// Basic check to ensure there's an ID part
+		pathParts := strings.Split(strings.TrimSuffix(r.URL.Path, "/"), "/")
+		if len(pathParts) < 3 || pathParts[2] == "" { // expecting /components/{id}
+			http.Error(w, "Component ID is missing in URL path", http.StatusBadRequest)
+			return
+		}
+		// The actual ID extraction is done within each specific handler as designed previously
+
+		switch r.Method {
+		case http.MethodGet:
+			compHandler.GetComponentByIDHandler(w, r)
+		case http.MethodPut:
+			compHandler.UpdateComponentHandler(w, r)
+		case http.MethodDelete:
+			compHandler.DeleteComponentHandler(w, r)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	// 2f. Start the HTTP server
+	port := "8080"
+	if p := os.Getenv("PORT"); p != "" {
+		port = p
+	}
+
+	server := &http.Server{
+		Addr:    ":" + port,
+		Handler: mux,
+	}
+
+	log.Printf("Server starting on port %s", port)
+
+	// 2g. Graceful shutdown
+	// Run server in a goroutine so that it doesn't block.
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Could not listen on %s: %v\n", server.Addr, err)
+		}
+	}()
+
+	// Listen for termination signals
+	stopChan := make(chan os.Signal, 1)
+	signal.Notify(stopChan, syscall.SIGINT, syscall.SIGTERM)
+	<-stopChan // Wait for signal
+
+	log.Println("Shutting down server...")
+
+	// Set a deadline for graceful shutdown.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := server.Shutdown(ctx); err != nil {
+		log.Fatalf("Server Shutdown Failed:%+v", err)
+	}
+
+	log.Println("Server exited properly")
+}

--- a/models/component.go
+++ b/models/component.go
@@ -1,0 +1,8 @@
+package models
+
+// Component represents a component in the system.
+type Component struct {
+	ID       string
+	Name     string
+	ParentID *string // Pointer to string for nullable UUID
+}

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,8 @@
+-- This file contains the SQL schema for the components table.
+
+CREATE TABLE components (
+    id UUID PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    parent_id UUID,
+    FOREIGN KEY (parent_id) REFERENCES components(id) ON DELETE SET NULL
+);


### PR DESCRIPTION
This commit introduces a new Golang service for managing hierarchical components.

Key features implemented:
- Defines a `Component` model (`models/component.go`) with ID, Name, and ParentID.
- Sets up a PostgreSQL database schema (`schema.sql`) for storing components.
- Implements database interaction logic (`db/postgres.go`) for Create, Read, Update, and Delete operations using the `database/sql` package and `lib/pq` driver.
- Provides REST API handlers (`handlers/component_handlers.go`) for all CRUD operations, including JSON request/response handling and error management.
- Includes a `main.go` that initializes the database, sets up HTTP routing using standard library features, and starts the server with graceful shutdown.
- Adds comprehensive unit tests for both database functions (`db/postgres_test.go`) and API handlers (`handlers/component_handlers_test.go`), requiring a test PostgreSQL database.
- Initializes Go modules (`go.mod`, `go.sum`).
- Creates a multi-stage `Dockerfile` for building a lean, static Go binary and containerizing the application.

The service is built using only the Go standard library, with the exception of the `lib/pq` PostgreSQL driver, which is a common and standard choice for `database/sql`. UUIDs for components are currently expected to be client-provided to adhere to the standard library constraint.

Further work would involve updating the README.md with build/run instructions, API documentation, and potentially integrating a built-in UUID generation mechanism if the standard library constraint can be relaxed.